### PR TITLE
Updating Header Matching to support Arrays

### DIFF
--- a/lib/frisby.js
+++ b/lib/frisby.js
@@ -506,7 +506,7 @@ Frisby.prototype.expectHeader = function(header, content) {
   var header = (header+"").toLowerCase();
   this.current.expects.push(function() {
     if(typeof self.current.response.headers[header] !== "undefined") {
-      expect(self.current.response.headers[header].toLowerCase()).toEqual(content.toLowerCase());
+      expect((self.current.response.headers[header]+"").toLowerCase()).toEqual(content.toLowerCase());
     } else {
       throw new Error("Header '" + header + "' not present in HTTP response");
     }
@@ -520,7 +520,7 @@ Frisby.prototype.expectHeaderContains = function(header, content) {
   var header = (header+"").toLowerCase();
   this.current.expects.push(function() {
     if(typeof self.current.response.headers[header] !== "undefined") {
-      expect(self.current.response.headers[header].toLowerCase()).toContain(content.toLowerCase());
+      expect((self.current.response.headers[header]+"").toLowerCase()).toContain(content.toLowerCase());
     } else {
       throw new Error("Header '" + header + "' not present in HTTP response");
     }
@@ -534,7 +534,7 @@ Frisby.prototype.expectHeaderToMatch = function(header, pattern) {
     var header = (header+"").toLowerCase();
     this.current.expects.push(function() {
         if(typeof self.current.response.headers[header] !== "undefined") {
-            expect(self.current.response.headers[header].toLowerCase()).toMatch(pattern);
+            expect((self.current.response.headers[header]+"").toLowerCase()).toMatch(pattern);
         } else {
             throw new Error("Header '" + header + "' does not match pattern '" + pattern + "' in HTTP response");
         }


### PR DESCRIPTION
When headers are parsed, cookie & set-cookie can be returned as arrays, causing the header matchers to call .toLowerCase() on an array. This change prevents exceptions and allows matching against these values.
